### PR TITLE
Remove deprecated virtualenv arguments --no-site-packages, --relocatable, dependency on unused VCS

### DIFF
--- a/dxr/cli/deploy.py
+++ b/dxr/cli/deploy.py
@@ -169,7 +169,7 @@ class Deployment(object):
         try:
             with cd(new_build_path):
                 # Make a fresh, blank virtualenv:
-                run('virtualenv -p {python} --no-site-packages {venv_name}',
+                run('virtualenv -p {python} {venv_name}',
                     python=self.python_path,
                     venv_name=VENV_NAME)
 
@@ -197,10 +197,6 @@ class Deployment(object):
                     run('make static &> /dev/null')
                     run('{pip} install --no-deps .',
                         pip=join(venv, 'bin', 'pip'))
-
-                # After installing, you always have to re-run this, even if we
-                # were reusing a venv:
-                run('virtualenv --relocatable {venv}', venv=venv)
 
                 run('chmod 755 .')  # mkdtemp uses a very conservative mask.
         except Exception:

--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -18,6 +18,7 @@ TODO:
 
 """
 from datetime import datetime
+import errno
 import marshal
 import os
 from os.path import exists, join, realpath, relpath, split
@@ -463,6 +464,15 @@ def file_contents_at_rev(source_folder, rel_file, revision):
                 return cls.get_contents(existent, join(nonexistent, file), revision, stderr=devnull)
             except subprocess.CalledProcessError:
                 continue
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    # ENOENT is thrown when the VCS utility is not found in PATH environment variable.
+                    # Catch the exception and try the next VCS.
+                    continue
+                else:
+                    raise
+    # Unable to fetch contents through any VCS
+    return None
 
 
 class VcsCache(object):


### PR DESCRIPTION
### Change 1:
Installing DXR to requires using Python 2.

The earliest version that successfully builds on AlmaLinux 8 is Python 2.7.15 which comes with `virtualenv` v20.15.1 which no longer supports the `--no-site-packages` and `--relocatable` arguments.

From `virtualenv` v15.1.0 `--help`:
Argument | Description
--- | --- 
--no-site-packages | DEPRECATED. Retained only for backward compatibility. Not having access to global site-packages is now the default behavior. 
--relocatable | Make an EXISTING virtualenv environment relocatable. This fixes up scripts and makes all .pth files relative.

### Change 2:
Function `file_contents_at_rev` tries to fetch in turn through Mercurial, Git, then Perforce.  An exception is thrown when the client utility required is not on `$PATH` and processing is terminated.

Catch the exception instead and try the next VCS.