### PR TITLE
Update dxr-index.cpp for clang 19

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -160,7 +160,12 @@ public:
 #endif
       StringRef searchPath,
       StringRef relativePath,
-      const Module *imported
+#if CLANG_AT_LEAST(19, 0)
+      const Module *suggestedModule,
+      bool moduleImported
+#else
+      const Module *suggestedModule
+#endif
 #if CLANG_AT_LEAST(12, 0)
       , SrcMgr::CharacteristicKind fileType
 #endif
@@ -416,11 +421,11 @@ public:
 #else
     const std::string anon_ns = "<anonymous namespace>";
 #endif
-    if (StringRef(ret).startswith(anon_ns)) {
+    if (StringRef(ret).starts_with(anon_ns)) {
       const std::string &realname = getRealFilenameForDefinition(d);
       ret = "(" + ret.substr(1, anon_ns.size() - 2) + " in " + realname + ")" +
         ret.substr(anon_ns.size());
-    } else if (d.getLinkageInternal() == InternalLinkage) {
+    } else if (d.getLinkageInternal() == Linkage::Internal) {
       const std::string &realname = getRealFilenameForDefinition(d);
       ret = "(static in " + realname + ")::" + ret;
     }
@@ -611,7 +616,7 @@ public:
     if (!interestingLocation(d->getLocation()))
       return true;
 
-    if (d->isThisDeclarationADefinition() || d->isPure()) {
+    if (d->isThisDeclarationADefinition() || d->isPureVirtual()) {
       SourceLocation functionLocation = d->getLocation();
       beginRecord("function", functionLocation);
       std::string functionName = d->getNameAsString();
@@ -1302,7 +1307,8 @@ public:
 #endif
       StringRef searchPath,
       StringRef relativePath,
-      const Module *imported) {
+      const Module *imported
+      ) {
     PresumedLoc presumedHashLoc = sm.getPresumedLoc(hashLoc);
     if (!interestingLocation(hashLoc) ||
         filenameRange.isInvalid() ||
@@ -1436,13 +1442,18 @@ void PreprocThunk::InclusionDirective(
 #endif
     StringRef searchPath,
     StringRef relativePath,
-    const Module *imported
+#if CLANG_AT_LEAST(19, 0)
+    const Module *suggestedModule,
+    bool moduleImported
+#else
+    const Module *suggestedModule
+#endif
 #if CLANG_AT_LEAST(12, 0)
     , SrcMgr::CharacteristicKind fileType
 #endif
     ) {
   real->InclusionDirective(hashLoc, includeTok, fileName, isAngled, filenameRange,
-                           file, searchPath, relativePath, imported);
+                           file, searchPath, relativePath, suggestedModule);
 }
 
 // Our plugin entry point.

--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -160,11 +160,9 @@ public:
 #endif
       StringRef searchPath,
       StringRef relativePath,
-#if CLANG_AT_LEAST(19, 0)
-      const Module *suggestedModule,
-      bool moduleImported
-#else
       const Module *suggestedModule
+#if CLANG_AT_LEAST(19, 0)
+      , bool moduleImported
 #endif
 #if CLANG_AT_LEAST(12, 0)
       , SrcMgr::CharacteristicKind fileType
@@ -421,11 +419,19 @@ public:
 #else
     const std::string anon_ns = "<anonymous namespace>";
 #endif
+#if CLANG_AT_LEAST(19, 0)
     if (StringRef(ret).starts_with(anon_ns)) {
+#else
+    if (StringRef(ret).startswith(anon_ns)) {
+#endif
       const std::string &realname = getRealFilenameForDefinition(d);
       ret = "(" + ret.substr(1, anon_ns.size() - 2) + " in " + realname + ")" +
         ret.substr(anon_ns.size());
+#if CLANG_AT_LEAST(19, 0)
     } else if (d.getLinkageInternal() == Linkage::Internal) {
+#else
+    } else if (d.getLinkageInternal() == InternalLinkage) {
+#endif
       const std::string &realname = getRealFilenameForDefinition(d);
       ret = "(static in " + realname + ")::" + ret;
     }
@@ -616,7 +622,11 @@ public:
     if (!interestingLocation(d->getLocation()))
       return true;
 
+#if CLANG_AT_LEAST(19, 0)
     if (d->isThisDeclarationADefinition() || d->isPureVirtual()) {
+#else
+    if (d->isThisDeclarationADefinition() || d->isPure()) {
+#endif
       SourceLocation functionLocation = d->getLocation();
       beginRecord("function", functionLocation);
       std::string functionName = d->getNameAsString();
@@ -1307,8 +1317,7 @@ public:
 #endif
       StringRef searchPath,
       StringRef relativePath,
-      const Module *imported
-      ) {
+      const Module *imported) {
     PresumedLoc presumedHashLoc = sm.getPresumedLoc(hashLoc);
     if (!interestingLocation(hashLoc) ||
         filenameRange.isInvalid() ||
@@ -1442,11 +1451,9 @@ void PreprocThunk::InclusionDirective(
 #endif
     StringRef searchPath,
     StringRef relativePath,
-#if CLANG_AT_LEAST(19, 0)
-    const Module *suggestedModule,
-    bool moduleImported
-#else
     const Module *suggestedModule
+#if CLANG_AT_LEAST(19, 0)
+    , bool moduleImported
 #endif
 #if CLANG_AT_LEAST(12, 0)
     , SrcMgr::CharacteristicKind fileType


### PR DESCRIPTION
	1. Llvm::StringRef::startswith -> starts_with
		a. https://github.com/llvm/llvm-project/commit/1b97645e56bf321b06d1353024339958b64fd242
	2. InclusionDirective args change
		a. https://github.com/llvm/llvm-project/commit/da95d926f6fce4ed9707c77908ad96624268f134#diff-a30a52c492d5e004b442fce506f7f473c7111af94df8e086adb9071579da74c8
	3. InternalLinkage refactor
		a. https://github.com/llvm/llvm-project/commit/8775947633bf189e1847707932b1015f04640ea0#diff-8d9d93807de75014c34572b263ffbf6dcf30b8b34caf11fcbc3a3c5a09c50155
	4. isPure -> isPureVirtual
		a. https://github.com/llvm/llvm-project/commit/e90e43fb9cd1d305f7196cd526aa503374e0f616
